### PR TITLE
Stereoscopic 3D Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,8 @@
-## Fork of T-Rex Game 3DS with Stereoscopic 3D support (in beta)
-Original - https://github.com/BlyZeDev/T-Rex-Game-3DS
+# T-Rex Game 3DS
+GBAtemp Thread: https://gbatemp.net/threads/release-chrome-t-rex-game-clone.661573
+
+### Controls:
+- A to jump
+- B to duck or fall faster when jumping
+
+### Have fun!

--- a/README.md
+++ b/README.md
@@ -1,8 +1,2 @@
-# T-Rex Game 3DS
-GBAtemp Thread: https://gbatemp.net/threads/release-chrome-t-rex-game-clone.661573
-
-### Controls:
-- A to jump
-- B to duck or fall faster when jumping
-
-### Have fun!
+## Fork of T-Rex Game 3DS with Stereoscopic 3D support (in beta)
+Original - https://github.com/BlyZeDev/T-Rex-Game-3DS

--- a/source/input.c
+++ b/source/input.c
@@ -9,6 +9,7 @@
 u32 kDown = 0;
 u32 kHeld = 0;
 u32 kUp = 0;
+float slider;
 
 touchPosition touchPos;
 
@@ -19,6 +20,8 @@ void updateInput()
     kDown = hidKeysDown() | hidKeysDownRepeat();
     kHeld = hidKeysHeld();
     kUp = hidKeysUp();
+
+    slider = osGet3DSliderState();
 
     hidTouchRead(&touchPos);
 }

--- a/source/input.h
+++ b/source/input.h
@@ -4,6 +4,7 @@
 extern u32 kDown;
 extern u32 kHeld;
 extern u32 kUp;
+extern float slider;
 
 extern touchPosition touchPos;
 

--- a/source/sprites.c
+++ b/source/sprites.c
@@ -6,6 +6,10 @@
 #include <citro2d.h>
 #include <citro3d.h>
 
+#include "input.h"
+
+int genericOffset = 50;
+
 typedef struct
 {
     C2D_Sprite* frames;
@@ -116,6 +120,7 @@ sprite initCloud(const C2D_SpriteSheet spriteSheet)
     C2D_Sprite curSprite;
 
     C2D_SpriteFromSheet(&curSprite, spriteSheet, 1);
+    C2D_SpriteSetScale(&curSprite, 1.5f, 1.5f);
     return initSprite(&curSprite, 1, 0);
 }
 
@@ -213,4 +218,18 @@ void renderSprite(sprite* spritePtr, const u32 frames)
     updateFrames(spritePtr, frames);
 
     C2D_DrawSprite(&spritePtr->frames[spritePtr->curIndex]);
+}
+
+// If int screen is 1 (left eye) - substract offset from sprite's X
+// If int screen is 2 (right eye) - add offset to sprite's X
+void renderSprite3D(sprite* spritePtr, const u32 frames, int screen)
+{
+    updateFrames(spritePtr, frames);
+
+    int standartX = spritePtr->frames->params.pos.x;
+    int standartY = spritePtr->frames->params.pos.y;
+    float offset = (screen == 1) ? -genericOffset * slider : genericOffset * slider;
+    C2D_SpriteSetPos(&spritePtr->frames[spritePtr->curIndex], standartX + offset, standartY);
+    C2D_DrawSprite(&spritePtr->frames[spritePtr->curIndex]);
+    C2D_SpriteSetPos(&spritePtr->frames[spritePtr->curIndex], standartX, standartY);
 }

--- a/source/sprites.h
+++ b/source/sprites.h
@@ -1,6 +1,8 @@
 #ifndef SPRITES_H
 #define SPRITES_H
 
+extern int genericOffset;
+
 typedef struct
 {
     C2D_Sprite* frames;
@@ -47,5 +49,7 @@ void setPlayerPos(player* playerPtr, const float x, const float y);
 void movePlayer(player* playerPtr, const float moveX, const float moveY);
 
 void renderSprite(sprite* spritePtr, const u32 frames);
+
+void renderSprite3D(sprite* spritePtr, const u32 frames, int screen);
 
 #endif


### PR DESCRIPTION
Added 3DS' Stereoscopic 3D effect support for game!  

It only affects on clouds (and they're a little bit bigger, so that the effect looks passable)

### Known issues:

- I couldn't make sprite animations and rendering for 2 eyes work together. When double rendering for each eye: animations are very buggy.
- Citro2d text rendering 2 times for each eye is very hard for system

That's why Dino and text are rendering only for left eye (which gives a little discomfort) (Bird is rendering for 2 eyes and his animation is, yeah... buggy)
I think if you spent some time you can figure out how solve this issues! :)